### PR TITLE
Make the "global" word list a list by "window" and refine score

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["tab"], "command": "hippie_word_completion", "context": [
+        { "key": "read_only", "operator": "not_equal" },
         { "key": "auto_complete_visible", "operand": false },
         { "key": "has_snippet", "operand": false  },
         { "key": "has_next_field", "operand": false },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["tab"], "command": "hippie_word_completion", "context": [
+        { "key": "read_only", "operator": "not_equal" },
         { "key": "auto_complete_visible", "operand": false },
         { "key": "has_snippet", "operand": false  },
         { "key": "has_next_field", "operand": false },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["tab"], "command": "hippie_word_completion", "context": [
+        { "key": "read_only", "operator": "not_equal" },
         { "key": "auto_complete_visible", "operand": false },
         { "key": "has_snippet", "operand": false  },
         { "key": "has_next_field", "operand": false },

--- a/hippie.py
+++ b/hippie.py
@@ -113,24 +113,36 @@ def fuzzyfind(primer, collection, sort_results=True):
 
 
 def fuzzy_score(primer, item):
-    start, pos, prev, score = -1, -1, 0, 1
+    start, pos, score = -1, -1, 1
+    len_item = len(item)
     item_l = item.lower()
     for c in primer:
-        pos = item_l.find(c, pos + 1)
+        pos = item_l.find(c)
         if pos == -1:
             return
         if start == -1:
             start = pos
+            if pos == 0:
+                score = -1  # match at the start of the word gets extra points
 
-        # Update score if not at start of the word
-        if pos > 0:
-            pc = item[pos - 1]
-            if pc in "_-" or pc.isupper() < item[pos].isupper():
-                continue
-        score += pos - prev
-        prev = pos
+        if (
+            pos > 0
+            and (pc := item[pos - 1])
+            and (
+                pc in "_-"
+                or pc.isupper() < item[pos].isupper()
+            )
+        ):
+            # no penalty if we matched exactly the next char
+            # or the first char of a sub-word
+            pass
+        else:
+            score += pos
 
-    return (score, len(item))
+        item_l = item_l[pos + 1:]
+        item = item[pos + 1:]
+
+    return (score, len_item)
 
 
 def ldistinct(seq):

--- a/hippie.py
+++ b/hippie.py
@@ -113,8 +113,7 @@ def fuzzyfind(primer, collection, sort_results=True):
 
 
 def fuzzy_score(primer, item):
-    start, pos, score = -1, -1, 1
-    len_item = len(item)
+    start, pos, prev, score = -1, -1, -1, 1
     item_l = item.lower()
     for c in primer:
         pos = item_l.find(c)
@@ -133,16 +132,14 @@ def fuzzy_score(primer, item):
                 or pc.isupper() < item[pos].isupper()
             )
         ):
-            # no penalty if we matched exactly the next char
-            # or the first char of a sub-word
+            # no penalty if we matched exactly the next char of a sub-word
             pass
         else:
-            score += pos
+            score += abs(pos - prev - 1)
 
-        item_l = item_l[pos + 1:]
-        item = item[pos + 1:]
+        prev = pos
 
-    return (score, len_item)
+    return (score, len(item))
 
 
 def ldistinct(seq):

--- a/hippie.py
+++ b/hippie.py
@@ -135,8 +135,10 @@ def fuzzy_score(primer, item):
             # no penalty if we matched exactly the next char of a sub-word
             pass
         else:
-            score += abs(pos - prev - 1)
+            score += 2 * abs(pos - prev - 1)
 
+        if score > 5:
+            return
         prev = pos
 
     return (score, len(item))

--- a/hippie.py
+++ b/hippie.py
@@ -43,19 +43,19 @@ class HippieWordCompletionCommand(sublime_plugin.TextCommand):
                     if initial_primer in history[window]
                     else set()
                 ),
-                words_by_view[window][self.view],
+                words_by_view[window][self.view] - {initial_primer},
                 (
                     set(flatten(words_by_view[window].values()))
                     - words_by_view[window][self.view]
+                    - {initial_primer}
                 )
             ))
 
             last_index = 0
-
-        if matching[last_index] == primer:
+        else:
             last_index += 1
-        if last_index >= len(matching):
-            last_index = 0
+            if last_index >= len(matching):
+                last_index = 0
 
         for region in self.view.sel():
             self.view.replace(edit, self.view.word(region), matching[last_index])


### PR DESCRIPTION
1. 
 
Really having *all* words in the box is probably a mistake as it is a) a
wildly large list and b) it suggests really not available tokens from
other projects.

2.
Refine `fuzzy_score`

- Give matches at the start 2 extra points
- Do not give penalty for consecutive matching characters (!)

The higher the score the unlikely we suggest it.  So we could as well
say the `score` is a "penalty".  For consecutive matches, we still payed
"1" (as in `pos - prev`); we remove here.

This is WIP as in this commit message `consectuv<TAB>` will not suggest
"consecutive".  ST was always able to fix simple typos as well.

Other than that this algorithm mostly suggests what ST suggests on
`alt-space` in the *same* order.
