### PR TITLE
Do not bind for "read_only" views

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["tab"], "command": "hippie_word_completion", "context": [
+        { "key": "read_only", "operator": "not_equal" },
         { "key": "auto_complete_visible", "operand": false },
         { "key": "has_snippet", "operand": false  },
         { "key": "has_next_field", "operand": false },

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["tab"], "command": "hippie_word_completion", "context": [
+        { "key": "read_only", "operator": "not_equal" },
         { "key": "auto_complete_visible", "operand": false },
         { "key": "has_snippet", "operand": false  },
         { "key": "has_next_field", "operand": false },

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["tab"], "command": "hippie_word_completion", "context": [
+        { "key": "read_only", "operator": "not_equal" },
         { "key": "auto_complete_visible", "operand": false },
         { "key": "has_snippet", "operand": false  },
         { "key": "has_next_field", "operand": false },


### PR DESCRIPTION
In "read_only" views the side effect of "editing the view" doesn't work anyway;
grabbing `tab` prevents for example GitSavvy to work properly on some its special
views.